### PR TITLE
Update workflow to use v4 of artifact actions

### DIFF
--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ env.listPublishDirectory }}
 


### PR DESCRIPTION
Update the workflow to use v4 of the artifact actions for uploading the 'github-pages' artifact.

* Change the `actions/upload-pages-artifact@v1` to `actions/upload-pages-artifact@v4` in the "Upload artifact" step in `.github/workflows/build-listing.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pesky12/PeskyBox/pull/1?shareId=b566d7da-578a-4f2f-a0ea-26945e788dfd).